### PR TITLE
Removed duplicate line

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,6 @@
   - "{{ provision_catalog_dir }}/plugins"
   - "{{ provision_download_dir }}/{{ provision_release_tag }}"
   - "{{ provision_content_dir }}/{{ provision_content_release_tag }}"
-  - "{{ provision_catalog_dir }}"
 
 - name: get catalog json
   get_url:


### PR DESCRIPTION
I just noticed `- "{{ provision_catalog_dir }}"` was listed twice in the task "create dr-provision directories".